### PR TITLE
Add helper for rlive DFS

### DIFF
--- a/ZZ/Bip/Main_pdr2_pre_test.cc
+++ b/ZZ/Bip/Main_pdr2_pre_test.cc
@@ -1,0 +1,32 @@
+#include "Prelude.hh"
+#include "Pdr2.hh"
+#include "ZZ_Netlist.hh"
+
+using namespace ZZ;
+
+int main(int argc, char** argv)
+{
+    ZZ_Init;
+
+    // Build simple netlist with one flop x holding constant 0
+    Netlist N;
+    Add_Pob(N, flop_init);
+    Add_Pob(N, properties);
+
+    Wire x = N.add(Flop_(0));
+    flop_init(x) = l_False;  // x starts at 0
+    x.set(0, x);             // x' = x
+
+    Wire bad = N.add(PO_(0), x); // property is ~x
+    properties.push(~bad);
+
+    Params_Pdr2 P;
+    Vec<Wire> props(1, bad);
+
+    Cube s(x);
+    Cube b(~x);
+    Cube core = approxPreRlive(N, props, P, s, b);
+
+    WriteLn "core size: %_", (uint) (core ? core.size() : 0);
+    return 0;
+}

--- a/ZZ/Bip/Pdr2.hh
+++ b/ZZ/Bip/Pdr2.hh
@@ -72,6 +72,11 @@ void setParams(const CLI& cli, Params_Pdr2& P);
 
 bool pdr2(NetlistRef N, const Vec<Wire>& props, const Params_Pdr2& P, Cex* cex, NetlistRef N_invar);
 
+// Convenience wrapper that initializes a Pdr2 engine and queries the over-approximate
+// predecessor core for cube 'b' relative to state cube 's'.
+Cube approxPreRlive(NetlistRef N, const Vec<Wire>& props, const Params_Pdr2& P,
+                    const Cube& s, const Cube& b);
+
 
 //mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm
 }


### PR DESCRIPTION
## Summary
- add `approxPre` helper inside `Pdr2` to compute predecessor cores for the new rlive nested DFS search